### PR TITLE
Remove prerelease attribute from component descriptor

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,7 +1,7 @@
 name: http-api
 title: HTTP API
-version: '4.4-preview'
-prerelease: true
+version: 4.4
+display_version: 4.4-preview
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
Removes the prerelease attribute from the component descriptor files ahead of the 4.4 release.

The built output can then be published to the dev server for review / preview.