### PR TITLE
Change xrefs from 4.4-preview to 4.4

### DIFF
--- a/modules/ROOT/pages/actions/handling-errors.adoc
+++ b/modules/ROOT/pages/actions/handling-errors.adoc
@@ -14,7 +14,7 @@ If errors occur while executing statements, the server will roll back the transa
 
 In this example, we send an invalid statement to the server in order to demonstrate error handling.
 
-For more information on the status codes, see xref:4.4-preview@status-codes:ROOT:index.adoc[Neo4j Status Codes].
+For more information on the status codes, see xref:4.4@status-codes:ROOT:index.adoc[Neo4j Status Codes].
 
 _Example request_
 

--- a/modules/ROOT/pages/discovery.adoc
+++ b/modules/ROOT/pages/discovery.adoc
@@ -7,7 +7,7 @@ The HTTP API uses the port `7474` for HTTP and the port `7473` for HTTPS.
 
 [TIP]
 ====
-See the xref:4.4-preview@operations-manual:ROOT:configuration/ports/index.adoc[Operations Manual -> Ports] for an overview of the Neo4j-specific ports.
+See the xref:4.4@operations-manual:ROOT:configuration/ports/index.adoc[Operations Manual -> Ports] for an overview of the Neo4j-specific ports.
 ====
 
 

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -9,7 +9,7 @@ Each HTTP request can include a list of statements, and for convenience you can 
 
 The server guards against orphaned transactions by using a timeout.
 If there are no requests for a given transaction within the timeout period, the server will roll it back.
-You can configure the timeout in the server configuration, by setting xref:4.4-preview@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.rest.transaction.idle_timeout[Operations Manual -> Configuration settings `dbms.rest.transaction.idle_timeout`] to the number of seconds before timeout.
+You can configure the timeout in the server configuration, by setting xref:4.4@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.rest.transaction.idle_timeout[Operations Manual -> Configuration settings `dbms.rest.transaction.idle_timeout`] to the number of seconds before timeout.
 The default timeout is `60` seconds.
 
 Responses from the HTTP API can be transmitted as JSON streams, resulting in better performance and lower memory overhead on the server side.
@@ -18,7 +18,7 @@ To use streaming, supply the header `X-Stream: true` with each request.
 [NOTE]
 ====
 * Literal line breaks are not allowed inside Cypher statements.
-* Cypher queries with `USING PERIODIC COMMIT` (see xref:4.4-preview@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[Cypher Manual -> `PERIODIC COMMIT` query hint]) may only be executed when creating a new transaction and immediately committing it with a single HTTP request (see xref::/actions/begin-and-commit-a-transaction-in-one-request.adoc[Begin and commit a transaction in one request] for how to do that).
+* Cypher queries with `USING PERIODIC COMMIT` (see xref:4.4@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[Cypher Manual -> `PERIODIC COMMIT` query hint]) may only be executed when creating a new transaction and immediately committing it with a single HTTP request (see xref::/actions/begin-and-commit-a-transaction-in-one-request.adoc[Begin and commit a transaction in one request] for how to do that).
 * When a request fails the transaction will be rolled back.
 By checking the result for the presence/absence of the `transaction` key you can figure out if the transaction is still open.
 ====
@@ -27,6 +27,6 @@ By checking the result for the presence/absence of the `transaction` key you can
 ====
 In order to speed up queries in repeated scenarios, try not to use literals but replace them with parameters wherever possible.
 This will let the server cache query plans.
-See xref:4.4-preview@cypher-manual:ROOT:syntax/parameters/index.adoc#cypher-parameters[Cypher Manual -> Parameters] for more information.
+See xref:4.4@cypher-manual:ROOT:syntax/parameters/index.adoc#cypher-parameters[Cypher Manual -> Parameters] for more information.
 ====
 

--- a/modules/ROOT/pages/security/index.adoc
+++ b/modules/ROOT/pages/security/index.adoc
@@ -3,7 +3,7 @@
 [[http-api-security]]
 = Authentication and authorization
 
-Authentication and authorization are enabled by default in Neo4j (refer to xref:4.4-preview@operations-manual:ROOT:authentication-authorization/index.adoc#auth[Operations Manual -> Authentication and authorization]).
+Authentication and authorization are enabled by default in Neo4j (refer to xref:4.4@operations-manual:ROOT:authentication-authorization/index.adoc#auth[Operations Manual -> Authentication and authorization]).
 With authentication and authorization enabled, requests to the HTTP API must be authorized using the username and password of a valid user.
 
 


### PR DESCRIPTION
The version attribute for Neo4j manuals has been changed from `4.4-preview` to `4.4`.

This PR updates xrefs from the HTTP API to other Neo4j manuals to target the 4.4 version of the relevant manual.