### PR TITLE
Remove the CTA for NODES

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -52,13 +52,5 @@ asciidoc:
     copyright: 2022
     common-license-page-uri: https://neo4j.com/docs/license/
     # attributes for doc links to other manuals in publish playbook
-    neo4j-base-uri: '' 
-    neo4j-docs-base-uri: /docs 
-    # page-ad-image: https://dist.neo4j.com/wp-content/uploads/20220901150057/Artboard-12.png
-    page-ad-overline-link: https://neo4j.com/nodes-2022
-    page-ad-overline: 16-17 November 2022
-    page-ad-title: NODES 2022
-    page-ad-description: Join us for a free, two-day virtual conference of technical presentations by developers and data scientists, solving problems with graphs.
-    page-ad-link: https://neo4j.com/nodes-2022
-    page-ad-underline-role: button
-    page-ad-underline: Save your space
+    neo4j-base-uri: ''
+    neo4j-docs-base-uri: /docs


### PR DESCRIPTION
Removes the ad for NODES 2022, added in #52