### PR TITLE
Accessibility: add alt text to the HTTP API flow diagram

### DIFF
--- a/modules/ROOT/pages/endpoints.adoc
+++ b/modules/ROOT/pages/endpoints.adoc
@@ -36,7 +36,7 @@ For more information, see xref:transactions.adoc#_commit_a_transaction[Run trans
 
 The overall flow of the API is illustrated below, with each box representing a separate HTTP request:
 
-image::http-cypher-transaction-api-flow.png[title="HTTP API flow"]
+image::http-cypher-transaction-api-flow.png["Flow diagram of the HTTP API transaction endpoints: from START a transaction is opened with POST /tx (BEGIN), queries run with POST /tx/\{n} (RUN), and it is closed with either POST /tx/\{n}/commit (COMMIT) or DELETE /tx/\{n} (ROLLBACK) before reaching END; a single POST /tx/commit combines BEGIN and COMMIT",title="HTTP API flow"]
 
 
 [[discovery-api]]


### PR DESCRIPTION
## What

Added descriptive alt text to the HTTP API transaction flow diagram in `endpoints.adoc` (WCAG 1.1.1). It previously had only a `title` attribute and no alt text.

The curly-brace placeholders in the alt text (`POST /tx/{n}`) are escaped as `\{n}` so Asciidoctor does not try to resolve them as attribute references.

## Note

The request/response header tables (`headers.adoc`) and endpoints table already render proper `<th>` header cells via Asciidoctor's implicit header-row detection (first row on a single line followed by a blank line), so no table changes were needed.

## Verification

`npm run verify:preview` completes with no warnings/errors, and the rendered `<img>` carries the full `alt` text with `{n}` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)